### PR TITLE
fix: avoid duplicate site name in page titles

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const { title, description = config.description } = Astro.props;
-const fullTitle = title === config.title ? title : `${title} | ${config.title}`;
+const fullTitle = title.includes(config.title) ? title : `${title} | ${config.title}`;
 const canonicalUrl = Astro.url.href;
 ---
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>