### PR TITLE
fix: resolve iOS toggle indicator sizing on initial page load

### DIFF
--- a/src/pages/spec/[version]/md.astro
+++ b/src/pages/spec/[version]/md.astro
@@ -446,9 +446,24 @@ const previewHtml = await unified()
       }
     }
 
-    // Initialize indicator position on load
-    if (togglePreview) {
-      updateIndicator(togglePreview);
+    // Initialize indicator position after layout is complete
+    // Use double requestAnimationFrame to ensure layout/paint is finished,
+    // which fixes sizing issues on iOS Safari initial page load
+    function initializeIndicator() {
+      if (togglePreview) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            updateIndicator(togglePreview);
+          });
+        });
+      }
+    }
+
+    // Wait for fonts to load before measuring, then initialize
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(initializeIndicator);
+    } else {
+      initializeIndicator();
     }
 
     // Toggle event listeners


### PR DESCRIPTION
Wait for fonts to load and use double requestAnimationFrame before
measuring toggle button dimensions. This ensures layout is complete
before calculating indicator position, fixing the visual glitch on
iOS Safari where the toggle appeared incorrectly sized until toggled.