### PR TITLE
fix: remove stale public/spec/* from update-specs add-paths

### DIFF
--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -1,0 +1,47 @@
+name: Update Specs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update specs
+        run: npm run update-specs
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "chore: update spec versions"
+          title: "chore: update spec versions"
+          body: |
+            Automated update of spec versions from upstream repository.
+
+            This PR was created by the update-specs workflow.
+          branch: update-specs
+          delete-branch: true
+          add-paths: |
+            src/content/spec/*


### PR DESCRIPTION
## Summary
- Remove unused `public/spec/*` from the workflow's `add-paths` configuration
- SVG diagrams are now written to `src/content/spec/` alongside markdown files, not `public/spec/`

## Test plan
- [ ] Verify the workflow file is valid YAML
- [ ] Manually trigger the update-specs workflow to confirm it still creates PRs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)