### PR TITLE
feat: replace theme toggle system icon with custom sun-moon SVG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The site is built to `dist/` and deployed to Cloudflare Workers.
 
 - **Astro 5.x** static site generator
 - **Tailwind CSS 4.x** for styling with dark mode support
-- **astro-icon** with Heroicons and Simple Icons for icons
+- **astro-icon** with Heroicons, Simple Icons, and custom local SVGs (`src/icons/`)
 - **Content Collections** for spec markdown files
 - **TypeScript** throughout
 - **Node.js** as JavaScript runtime (managed via mise)

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -14,11 +14,7 @@ import { Icon } from "astro-icon/components";
   >
     <Icon name="heroicons:sun" data-theme-icon="light" class="hidden w-5 h-5" />
     <Icon name="heroicons:moon" data-theme-icon="dark" class="hidden w-5 h-5" />
-    <Icon
-      name="heroicons:computer-desktop"
-      data-theme-icon="auto"
-      class="hidden w-5 h-5"
-    />
+    <Icon name="sun-moon" data-theme-icon="auto" class="hidden w-5 h-5" />
   </button>
   <!-- Tooltip -->
   <div

--- a/src/icons/sun-moon.svg
+++ b/src/icons/sun-moon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <!-- Circle outline -->
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>
+  <!-- Right half filled (dark/moon side) -->
+  <path fill="currentColor" d="M12 8.25a3.75 3.75 0 0 1 0 7.5z"/>
+  <!-- Left-side sun rays (top, top-left, left, bottom-left, bottom) -->
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v2.25M7.227 7.227 5.636 5.636M5.25 12H3M7.227 16.773l-1.591 1.591M12 18.75V21"/>
+</svg>


### PR DESCRIPTION
## Summary

The theme toggle's system/auto state used a generic computer-desktop icon that didn't visually relate to the sun (light) and moon (dark) icons used for the other two states.

This replaces it with a custom sun-moon SVG icon — a sun circle with the right half filled dark and only left-side rays — that clearly conveys "both light and dark" for the automatic theme preference.

- Added `src/icons/sun-moon.svg` as a local astro-icon SVG matching the heroicons outline style (24x24, stroke-width 1.5, rounded caps/joins)
- Updated `ThemeToggle.astro` to reference the new local icon
- Documented `src/icons/` as a local icon directory in `CLAUDE.md`

## Test plan

- [ ] Run `npm run build` — verify no build errors
- [ ] Run `npm run dev` — cycle the theme toggle through all three states and confirm the new icon renders correctly for the system/auto state
- [ ] Verify icon looks correct in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)